### PR TITLE
netcoreapp-2.0 Updating avro projects to support net core 2.0 and 451

### DIFF
--- a/AvroTestApp/AvroTestApp.csproj
+++ b/AvroTestApp/AvroTestApp.csproj
@@ -1,26 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <AssemblyName>AvroTestApp</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp1.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'net46' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'net45' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
+    <Description>Test Application for Microsoft Avro libraries</Description>
+    <PackageTags>Avro</PackageTags>
+    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+	<RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.16.04-x64;ubuntu.16.04-x86</RuntimeIdentifiers>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <OutputPath>bin\</OutputPath>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001507-00</RuntimeFrameworkVersion> 
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>
+  <Import Project="..\build.props" />
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Avro.Core\Microsoft.Avro.Core.csproj" />
   </ItemGroup>

--- a/Microsoft.Avro.Core/AvroEnum.cs
+++ b/Microsoft.Avro.Core/AvroEnum.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Hadoop.Avro
         /// <value>
         /// The integer value.
         /// </value>
-        internal int IntegerValue
+        public int IntegerValue
         {
             get
             {

--- a/Microsoft.Avro.Core/Microsoft.Avro.Core.csproj
+++ b/Microsoft.Avro.Core/Microsoft.Avro.Core.csproj
@@ -1,42 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp1.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Avro.Core</AssemblyName>
-    <RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.16.04-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1'">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001507-00</RuntimeFrameworkVersion> 
+    <Description>Core library for the Microsoft Avro libraries</Description>
+    <PackageTags>Avro</PackageTags>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup>
-    <OutputPath>bin\</OutputPath>
-  </PropertyGroup>
+  <Import Project="..\build.props"/>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)"/>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Utils\Templates\ClassTemplate.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
-    <None Update="Utils\Templates\EnumTemplate.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-    </None>
   </ItemGroup>
 </Project>

--- a/Microsoft.Avro.Core/Properties/AssemblyInfo.cs
+++ b/Microsoft.Avro.Core/Properties/AssemblyInfo.cs
@@ -14,16 +14,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-//[assembly: AssemblyTitle("Microsoft.Avro.Core")]
-//[assembly: AssemblyProduct("Microsoft.Avro.Core")]
-[assembly: Guid("109bd5a1-5f33-47b1-83ee-a57269b4da87")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(true)]
-//[assembly: NeutralResourcesLanguage("en-US")]
 
 #if CODESIGN
 [assembly: InternalsVisibleTo("Microsoft.Avro.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/Microsoft.Avro.Core/Schema/ReflectionSchemaBuilder.cs
+++ b/Microsoft.Avro.Core/Schema/ReflectionSchemaBuilder.cs
@@ -214,12 +214,12 @@ namespace Microsoft.Hadoop.Avro.Schema
                 .SingleOrDefault(t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof(IDictionary<,>));
 
             if (dictionaryType != null
-                && (dictionaryType.GetGenericArguments()[0] == typeof(string)
-                 || dictionaryType.GetGenericArguments()[0] == typeof(Uri)))
+                && (dictionaryType.GenericTypeArguments[0] == typeof(string)
+                 || dictionaryType.GenericTypeArguments[0] == typeof(Uri)))
             {
                 return new MapSchema(
-                    this.CreateNotNullableSchema(dictionaryType.GetGenericArguments()[0], schemas, currentDepth + 1),
-                    this.CreateSchema(false, dictionaryType.GetGenericArguments()[1], schemas, currentDepth + 1),
+                    this.CreateNotNullableSchema(dictionaryType.GenericTypeArguments[0], schemas, currentDepth + 1),
+                    this.CreateSchema(false, dictionaryType.GenericTypeArguments[1], schemas, currentDepth + 1),
                     type);
             }
 
@@ -229,7 +229,7 @@ namespace Microsoft.Hadoop.Avro.Schema
                 .SingleOrDefault(t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>));
             if (enumerableType != null)
             {
-                var itemType = enumerableType.GetGenericArguments()[0];
+                var itemType = enumerableType.GetTypeInfo().GetGenericArguments()[0];
                 return new ArraySchema(this.CreateSchema(false, itemType, schemas, currentDepth + 1), type);
             }
 

--- a/Microsoft.Avro.Core/Serializers/UnionSerializer.cs
+++ b/Microsoft.Avro.Core/Serializers/UnionSerializer.cs
@@ -173,12 +173,12 @@ namespace Microsoft.Hadoop.Avro.Serializers
 
         private int MoreSpecializedTypesFirst(IndexedSchema s1, IndexedSchema s2)
         {
-            if (s1.Schema.RuntimeType.GetTypeInfo().IsAssignableFrom(s2.Schema.RuntimeType))
+            if (s1.Schema.RuntimeType.IsAssignableFrom(s2.Schema.RuntimeType))
             {
                 return 1;
             }
 
-            if (s2.Schema.RuntimeType.GetTypeInfo().IsAssignableFrom(s1.Schema.RuntimeType))
+            if (s2.Schema.RuntimeType.IsAssignableFrom(s1.Schema.RuntimeType))
             {
                 return -1;
             }
@@ -263,7 +263,7 @@ namespace Microsoft.Hadoop.Avro.Serializers
                 var mapSchema = this.itemSchemas[i] as MapSchema;
                 if (mapSchema != null)
                 {
-                    var valueType = dictionary.GetType().GetTypeInfo().GetGenericArguments()[1];
+                    var valueType = dictionary.GetType().GetGenericArguments()[1];
                     if (mapSchema.ValueSchema.RuntimeType == valueType)
                     {
                         encoder.Encode(i);

--- a/Microsoft.Avro.Core/TypeExtensions.cs
+++ b/Microsoft.Avro.Core/TypeExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Hadoop.Avro
         /// <returns>True if type t has a public parameter-less constructor, false otherwise.</returns>
         public static bool HasParameterlessConstructor(this Type type)
         {
-            return type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null;
+            return type.GetConstructor(Type.EmptyTypes) != null;
         }
 
         /// <summary>
@@ -107,8 +107,8 @@ namespace Microsoft.Hadoop.Avro
         {
             return type.GetTypeInfo().IsClass
                 && type.GetTypeInfo().GetCustomAttributes(false).Any(a => a is CompilerGeneratedAttribute)
-                && !type.IsNested
-                && type.Name.StartsWith("<>", StringComparison.Ordinal)
+                && !type.GetTypeInfo().IsNested
+                && type.GetTypeInfo().Name.StartsWith("<>", StringComparison.Ordinal)
                 && type.Name.Contains("__Anonymous");
         }
 
@@ -244,10 +244,10 @@ namespace Microsoft.Hadoop.Avro
                    && ! type.IsUnsupported()
                    && (type.GetTypeInfo().IsSubclassOf(baseType) 
                    || type == baseType 
-                   || (baseType.GetTypeInfo().IsInterface && baseType.GetTypeInfo().IsAssignableFrom(type))
+                   || (baseType.GetTypeInfo().IsInterface && baseType.IsAssignableFrom(type))
                    || (baseType.GetTypeInfo().IsGenericType && baseType.GetTypeInfo().IsInterface && baseType.GenericIsAssignable(type)
                            && type.GetGenericArguments()
-                                  .Zip(baseType.GetTypeInfo().GetGenericArguments(), (type1, type2) => new Tuple<Type, Type>(type1, type2))
+                                  .Zip(baseType.GetGenericArguments(), (type1, type2) => new Tuple<Type, Type>(type1, type2))
                                   .ToList()
                                   .TrueForAll(tuple => CanBeKnownTypeOf(tuple.Item1, tuple.Item2))));
         }

--- a/Microsoft.Avro.Tests/Microsoft.Avro.Tests.csproj
+++ b/Microsoft.Avro.Tests/Microsoft.Avro.Tests.csproj
@@ -1,29 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!--
-  <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore">
-      <Version>1.0.0-*</Version>
-    </DotNetCliToolReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="CodeGenTests\" />
-  </ItemGroup>
-  <Target Name="PrecompileScript" BeforeTargets="Build" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
-    <Exec Command="dotnet SpecFlow.NetCore" />
-  </Target>
-  -->
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp1.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Avro.Tests</AssemblyName>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;netcore50;portable-net451+win8</PackageTargetFallback>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;netcore50;portable-net451+win8</PackageTargetFallback>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'net46' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <OutputPath>bin\</OutputPath>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001507-00</RuntimeFrameworkVersion>
+	  <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+    <Description>Tests Microsoft Avro libraries</Description>
+    <PackageTags>Avro</PackageTags>
   </PropertyGroup>
+  <Import Project="..\build.props" />
   <ItemGroup>
     <Compile Remove="CodeGenTests\CodeGenerationTests.cs" />
     <Compile Remove="CodeGenTests\CodeGenerationVerificationSteps.cs" />
@@ -31,16 +13,20 @@
     <Compile Remove="SchemaTests\ReflectionSchemaBuilderTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Avro.Core\Microsoft.Avro.Core.csproj" />
-    <ProjectReference Include="..\Microsoft.Avro.Tools\Microsoft.Avro.Tools.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.core" Version="2.2.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.2.0" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="SpecFlow.NetCore">
-      <Version>1.0.0-*</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="SpecFlow.NetCore" Version="1.0.0-*" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+      <PackageReference Include="SpecFlow" Version="2.1.0" />
+      <Reference Include="System" />
+      <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Avro">
@@ -53,19 +39,9 @@
       <HintPath>..\external\protobuf.net\r602\net30\protobuf-net.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1-*" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
-    <Folder Include="CodeGenTests\" />
+    <ProjectReference Include="..\Microsoft.Avro.Core\Microsoft.Avro.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.Avro.Tools\Microsoft.Avro.Tools.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Microsoft.Avro.Tests/Properties/AssemblyInfo.cs
+++ b/Microsoft.Avro.Tests/Properties/AssemblyInfo.cs
@@ -6,11 +6,10 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-//[assembly: AssemblyTitle("Microsoft.Avro.Tests")]
-//[assembly: AssemblyProduct("Microsoft.Avro.Tests")]
+//[assembly: AssemblyTitle("Microsoft.Hadoop.Avro.Tests")]
+//[assembly: AssemblyProduct("Microsoft.Hadoop.Avro.Tests")]
 
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("1EF64785-D024-4038-AFAC-145686F66606")]

--- a/Microsoft.Avro.Tools/Microsoft.Avro.Tools.csproj
+++ b/Microsoft.Avro.Tools/Microsoft.Avro.Tools.csproj
@@ -1,28 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- 
-    <PackageReference Include="System.Runtime.Serialization.Formatters">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    -->
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp1.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' != 'true'">netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
+    <AssemblyName>Microsoft.Avro.Tools</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;dotnet5.4;portable-net451+win8</PackageTargetFallback>
+    <Description>Tools for Microsoft Avro libraries</Description>
+    <PackageTags>Avro</PackageTags>
+    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+	<RuntimeIdentifiers>win7-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <OutputPath>bin\</OutputPath>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001507-00</RuntimeFrameworkVersion> 
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Reflection" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+  <Import Project="..\build.props" />
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Avro.Core\Microsoft.Avro.Core.csproj" />
   </ItemGroup>

--- a/Microsoft.Avro.Tools/Properties/AssemblyInfo.cs
+++ b/Microsoft.Avro.Tools/Properties/AssemblyInfo.cs
@@ -7,8 +7,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-//[assembly: AssemblyTitle("Microsoft.Avro.Tools")]
-//[assembly: AssemblyProduct("Microsoft.Avro.Tools")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -17,7 +15,6 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("53c03b8e-d7e1-44b7-b095-f8572a3288b1")]
 //[assembly: NeutralResourcesLanguage("en-US")]
 
 #if CODESIGN

--- a/MicrosoftAvro.sln
+++ b/MicrosoftAvro.sln
@@ -1,12 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25920.0
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AvroTestApp", "AvroTestApp\AvroTestApp.csproj", "{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}"
-	ProjectSection(ProjectDependencies) = postProject
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D} = {266CAE56-5DF3-4A0E-BCDC-85384241D18D}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Avro.Core", "Microsoft.Avro.Core\Microsoft.Avro.Core.csproj", "{266CAE56-5DF3-4A0E-BCDC-85384241D18D}"
 EndProject
@@ -16,62 +13,26 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Avro.Tools", "Mic
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|x64.ActiveCfg = Debug|x64
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|x64.Build.0 = Debug|x64
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|x86.ActiveCfg = Debug|x86
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|x86.Build.0 = Debug|x86
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|x64.ActiveCfg = Release|x64
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|x64.Build.0 = Release|x64
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|x86.ActiveCfg = Release|x86
-		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|x86.Build.0 = Release|x86
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Debug|x64.Build.0 = Debug|Any CPU
+		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|x64.ActiveCfg = Release|Any CPU
+		{9A34E8A1-23BA-49D3-B189-1320A38E3FFB}.Release|x64.Build.0 = Release|Any CPU
 		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Debug|x64.Build.0 = Debug|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Debug|x86.Build.0 = Debug|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Release|x64.ActiveCfg = Release|Any CPU
 		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Release|x64.Build.0 = Release|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Release|x86.ActiveCfg = Release|Any CPU
-		{266CAE56-5DF3-4A0E-BCDC-85384241D18D}.Release|x86.Build.0 = Release|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Debug|x64.Build.0 = Debug|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Debug|x86.Build.0 = Debug|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Release|x64.ActiveCfg = Release|Any CPU
 		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Release|x64.Build.0 = Release|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Release|x86.ActiveCfg = Release|Any CPU
-		{FC8A5481-9794-4EB2-93BF-B05FC25DD9C3}.Release|x86.Build.0 = Release|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Debug|x64.Build.0 = Debug|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Debug|x86.Build.0 = Debug|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Release|x64.ActiveCfg = Release|Any CPU
 		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Release|x64.Build.0 = Release|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Release|x86.ActiveCfg = Release|Any CPU
-		{837E6085-427A-40D4-9789-7FEE036F0DCC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.props
+++ b/build.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.16.0</Version>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft</Owners>
+    <ProductId>$(AssemblyName)</ProductId>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Copyright>Microsoft</Copyright>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <DefaultItemExcludes>$(DefaultItemExcludes);packages.config;*.nuspec</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>..\bin\$(AssemblyName)</OutputPath>
+    <NewtonsoftVersion>10.0.1</NewtonsoftVersion>
+  </PropertyGroup>
+
+</Project>
+


### PR DESCRIPTION
With this change, avro builds in VS2017 projects and targets .net451 as
well as netcore2.0, with libraries targeting netstandard 2.0.