### PR TITLE
Fix list serialization of complex class with Dictionary field.

### DIFF
--- a/Microsoft.Avro.Core/Serializers/EnumerableSerializer.cs
+++ b/Microsoft.Avro.Core/Serializers/EnumerableSerializer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Hadoop.Avro.Serializers
                 Expression.Assign(buffer, Expression.New(listType)),
                 Expression.Assign(counter, Expression.Constant(0)),
                 Expression.Assign(enumerator, Expression.Call(value, getEnumerator)),
+                Expression.Assign(chunkCounter, Expression.Constant(0)),
                 Expression.Loop(
                     Expression.IfThenElse(
                         Expression.NotEqual(Expression.Call(enumerator, moveNext), Expression.Constant(false)),

--- a/Microsoft.Avro.Tests/AvroSerializerTests.cs
+++ b/Microsoft.Avro.Tests/AvroSerializerTests.cs
@@ -105,6 +105,16 @@ namespace Microsoft.Hadoop.Avro.Tests
         }
 
         [Fact]
+        public void Serializer_SerializeListOfComplexNestedClass()
+        {
+            RoundTripSerializationWithCheck(new List<ComplexNestedClass>
+            {
+                ComplexNestedClass.Create(),
+                ComplexNestedClass.Create()
+            });
+        }
+
+        [Fact]
         public void Serializer_SerializeGuidClass()
         {
             RoundTripSerializationWithCheck(ClassOfGuid.Create(true));

--- a/Microsoft.Avro.Tests/TestClasses/TestClasses.cs
+++ b/Microsoft.Avro.Tests/TestClasses/TestClasses.cs
@@ -573,6 +573,10 @@ namespace Microsoft.Hadoop.Avro.Tests
         [DataMember]
         public Recursive RecursiveField { get; set; }
 
+        [ProtoMember(4)]
+        [DataMember]
+        public Dictionary<int, string> DictionaryField { get; set; }
+
         public static Random R = new Random(typeof(ComplexNestedClass).GetHashCode());
 
         public static ComplexNestedClass Create()
@@ -581,7 +585,8 @@ namespace Microsoft.Hadoop.Avro.Tests
             {
                 NestedField = SimpleFlatClass.Create(),
                 IntNestedField = R.Next(),
-                RecursiveField = Recursive.Create()
+                RecursiveField = Recursive.Create(),
+                DictionaryField = new Dictionary<int, string> {[R.Next()] = $"val:{R.Next()}"}
             };
         }
 
@@ -598,6 +603,11 @@ namespace Microsoft.Hadoop.Avro.Tests
             }
 
             if (!this.NestedField.Equals(other.NestedField))
+            {
+                return false;
+            }
+
+            if (this.DictionaryField.Count != other.DictionaryField.Count || this.DictionaryField.Except(other.DictionaryField).Any())
             {
                 return false;
             }


### PR DESCRIPTION
Fixes #18 - Serializing a list of complex classes throws SerializationException - Invalid integer value in the input stream. Specifically, serialization would fail if the complex class had a Dictionary field where the dictionary key was anything  other than a string.